### PR TITLE
Add project-scoped daemon (start/stop/status/logs)

### DIFF
--- a/ghost/cli.py
+++ b/ghost/cli.py
@@ -3,7 +3,11 @@ Ghost CLI - The main entry point for the Ghost test generator.
 
 Usage:
     ghost init [PATH]           Initialize Ghost in a directory
-    ghost watch [PATH]          Watch for file changes and generate tests
+    ghost start [PATH]          Start file watcher (background daemon or foreground)
+    ghost stop [PATH]           Stop the background daemon
+    ghost status [PATH]         Show daemon status
+    ghost logs [PATH]           View daemon logs
+    ghost watch [PATH]          Watch for file changes and generate tests (foreground)
     ghost generate <FILE>       Generate tests for a specific file
     ghost config                Configure Ghost settings
     ghost providers             List available AI providers
@@ -13,6 +17,8 @@ Usage:
 import os
 import sys
 import time
+import signal
+import subprocess
 from pathlib import Path
 from typing import Optional
 
@@ -97,8 +103,15 @@ def cli(ctx, version):
     \b
     Quick Start:
       $ ghost init              # Initialize in current directory
-      $ ghost watch             # Start watching for changes
+      $ ghost start             # Start watching (background daemon)
       $ ghost generate app.py   # Generate tests for a file
+    
+    \b
+    Daemon Management:
+      $ ghost start             # Start background daemon
+      $ ghost stop              # Stop background daemon
+      $ ghost status            # Show daemon status
+      $ ghost logs              # View daemon logs
     
     \b
     Configuration:
@@ -428,6 +441,322 @@ def watch(path: str, verbose: bool):
     except Exception as e:
         Console.error(f"Watcher error: {e}")
         raise SystemExit(1)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DAEMON MANAGEMENT COMMANDS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _daemon_pid_file(project_root: Path) -> Path:
+    """Get the PID file path for a project."""
+    return project_root / GHOST_DIR / "pid"
+
+
+def _daemon_log_file(project_root: Path) -> Path:
+    """Get the log file path for a project."""
+    return project_root / GHOST_DIR / "logs" / "ghost.log"
+
+
+def _check_daemon(project_root: Path) -> Optional[int]:
+    """Check if a daemon is running for the given project.
+
+    Returns:
+        PID if running, None otherwise.
+    """
+    from daemon import check_pid
+    return check_pid(_daemon_pid_file(project_root))
+
+
+@cli.command()
+@click.argument('path', type=click.Path(), default='.')
+@click.option('--detach/--foreground', 'detach', default=True,
+              help='Run in background (default: detach)')
+def start(path: str, detach: bool):
+    """
+    Start the Ghost file watcher.
+
+    Runs the file watcher either in the foreground or as a background daemon.
+
+    \b
+    Examples:
+      ghost start                  # Start in background (daemon)
+      ghost start --detach         # Start in background (explicit)
+      ghost start --foreground     # Start in foreground
+      ghost start ./src            # Start in a specific directory
+    """
+    Console.mini_banner()
+
+    target_path = Path(path).resolve()
+
+    # Check for ghost.toml
+    ghost_file = target_path / GHOST_CONFIG_FILE
+    if not ghost_file.exists():
+        Console.warning("ghost.toml not found. Running 'ghost init' first...")
+        Console.newline()
+        ctx = click.get_current_context()
+        ctx.invoke(init, path=str(target_path))
+
+    pid_file = _daemon_pid_file(target_path)
+
+    if detach:
+        # ── Background daemon mode ───────────────────────────────────────
+
+        # Check if already running
+        existing_pid = _check_daemon(target_path)
+        if existing_pid is not None:
+            Console.warning(f"Daemon already running (PID: {existing_pid})")
+            Console.info(f"Use 'ghost stop' to stop it first, or 'ghost logs' to view output")
+            return
+
+        Console.info(f"Starting daemon for {target_path.name}...")
+
+        # Launch daemon as a detached subprocess
+        # start_new_session=True calls setsid(), detaching from terminal
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "ghost.daemon", str(target_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            cwd=str(target_path),
+        )
+
+        # Give it a moment to bootstrap (write PID, start observer)
+        time.sleep(0.5)
+
+        # Check if it started successfully
+        if proc.poll() is not None:
+            Console.error("Daemon failed to start")
+            # Check log for details
+            log_file = _daemon_log_file(target_path)
+            if log_file.exists():
+                last_lines = log_file.read_text().splitlines()[-5:]
+                for line in last_lines:
+                    Console.print(f"  {Colors.DIM}{line}{Colors.RESET}")
+            raise SystemExit(1)
+
+        # Write PID file (Popen launched the child; the daemon also writes it,
+        # but we write it here too so there's no race window)
+        pid_file.parent.mkdir(parents=True, exist_ok=True)
+        pid_file.write_text(str(proc.pid))
+
+        Console.success(f"Daemon started (PID: {proc.pid})")
+        Console.info(f"Logs: {_daemon_log_file(target_path)}")
+        Console.info("Use 'ghost status' to check daemon health")
+        Console.info("Use 'ghost stop' to stop the daemon")
+
+    else:
+        # ── Foreground mode ──────────────────────────────────────────────
+        Console.section("Starting File Watcher (Foreground)")
+
+        try:
+            import main as ghost_main
+
+            ghost_main.logging_setup()
+            ghost_main.start_watching(target_path)
+        except KeyboardInterrupt:
+            Console.newline()
+            Console.info("Stopping watcher...")
+            Console.success("Ghost stopped. Goodbye! 👻")
+        except Exception as e:
+            Console.error(f"Watcher error: {e}")
+            raise SystemExit(1)
+
+
+@cli.command()
+@click.argument('path', type=click.Path(), default='.')
+def stop(path: str):
+    """
+    Stop the Ghost daemon for a project.
+
+    Sends SIGTERM for graceful shutdown, then SIGKILL if it doesn't stop.
+
+    \b
+    Examples:
+      ghost stop              # Stop daemon for current project
+      ghost stop ./src        # Stop daemon for specific project
+    """
+    Console.mini_banner()
+
+    target_path = Path(path).resolve()
+    pid = _check_daemon(target_path)
+
+    if pid is None:
+        Console.warning("Daemon is not running")
+        return
+
+    Console.info(f"Stopping daemon (PID: {pid})...")
+
+    # Send SIGTERM for graceful shutdown
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as e:
+        Console.error(f"Failed to signal daemon: {e}")
+        # Clean up stale PID file anyway
+        _daemon_pid_file(target_path).unlink(missing_ok=True)
+        return
+
+    # Wait for graceful shutdown (up to 10 seconds)
+    with GhostSpinner("Waiting for daemon to stop", style=SpinnerStyle.DOTS, color=Colors.YELLOW) as spinner:
+        for i in range(20):  # 20 × 0.5s = 10s timeout
+            time.sleep(0.5)
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                spinner.stop(message="Daemon stopped gracefully")
+                return
+
+        # Force kill if grace period expired
+        Console.warning("Grace period expired, force killing...")
+        try:
+            os.kill(pid, signal.SIGKILL)
+            time.sleep(0.5)
+            Console.success("Daemon terminated")
+        except OSError as e:
+            Console.error(f"Failed to force kill: {e}")
+
+    # Clean up PID file
+    _daemon_pid_file(target_path).unlink(missing_ok=True)
+
+
+@cli.command()
+@click.argument('path', type=click.Path(), default='.')
+def status(path: str):
+    """
+    Show the daemon status for a project.
+
+    Reports whether the daemon is running, its PID, and recent log entries.
+
+    \b
+    Examples:
+      ghost status            # Show status for current project
+      ghost status ./src      # Show status for specific project
+    """
+    Console.mini_banner()
+
+    target_path = Path(path).resolve()
+    pid = _check_daemon(target_path)
+    log_file = _daemon_log_file(target_path)
+    pid_file = _daemon_pid_file(target_path)
+
+    Console.section("Daemon Status")
+
+    if pid is not None:
+        Console.success(f"Running (PID: {pid})", prefix="")
+        Console.info(f"PID file: {pid_file}")
+        Console.info(f"Log file: {log_file}")
+    else:
+        Console.warning("Not running", prefix="")
+
+    # Show recent log entries
+    if log_file.exists():
+        Console.newline()
+        Console.print(f"  {Colors.BOLD}Recent log entries:{Colors.RESET}")
+        Console.print(f"  {Colors.DIM}{'─' * 50}{Colors.RESET}")
+
+        try:
+            lines = log_file.read_text().splitlines()
+            # Show last 10 lines
+            for line in lines[-10:]:
+                Console.print(f"  {Colors.DIM}{line}{Colors.RESET}")
+        except OSError as e:
+            Console.warning(f"Cannot read log file: {e}")
+
+    Console.newline()
+
+    if pid is not None:
+        Console.info("Commands:")
+        Console.print(f"  {Colors.CYAN}ghost stop{Colors.RESET}    Stop the daemon")
+        Console.print(f"  {Colors.CYAN}ghost logs -f{Colors.RESET}  Follow log output")
+    else:
+        Console.info("Run 'ghost start' to start the daemon")
+
+
+@cli.command()
+@click.argument('path', type=click.Path(), default='.')
+@click.option('--follow', '-f', is_flag=True, help='Follow log output in real-time')
+@click.option('--lines', '-n', type=int, default=20, help='Number of lines to show (default: 20)')
+def logs(path: str, follow: bool, lines: int):
+    """
+    View the daemon log file.
+
+    Displays recent log entries or follows the log in real-time (like tail -f).
+
+    \b
+    Examples:
+      ghost logs               # Show last 20 log lines
+      ghost logs -n 50         # Show last 50 lines
+      ghost logs --follow      # Tail the log in real-time
+      ghost logs -f            # Short form of --follow
+    """
+    Console.mini_banner()
+
+    target_path = Path(path).resolve()
+    log_file = _daemon_log_file(target_path)
+
+    if not log_file.exists():
+        # Check if there's a project root with ghost.toml
+        project_root = _find_project_root(target_path)
+        if project_root:
+            log_file = _daemon_log_file(project_root)
+            if not log_file.exists():
+                Console.warning("No log file found. Is the daemon running?")
+                Console.info("Run 'ghost start' to start the daemon")
+                return
+        else:
+            Console.warning("No Ghost project found. Run 'ghost init' first.")
+            return
+
+    if follow:
+        # ── Tail mode (like tail -f) ─────────────────────────────────────
+        Console.info(f"Following log file: {log_file}")
+        Console.info("Press Ctrl+C to stop")
+        Console.newline()
+
+        try:
+            with open(log_file, "r") as f:
+                # Go to end of file
+                f.seek(0, 2)
+
+                while True:
+                    line = f.readline()
+                    if line:
+                        sys.stdout.write(line)
+                        sys.stdout.flush()
+                    else:
+                        # Check if daemon died
+                        pid = _check_daemon(target_path)
+                        if pid is None:
+                            Console.newline()
+                            Console.warning("Daemon has stopped")
+                            break
+                        time.sleep(0.1)
+        except KeyboardInterrupt:
+            Console.newline()
+            Console.info("Log follow stopped")
+        except OSError as e:
+            Console.error(f"Error reading log: {e}")
+    else:
+        # ── Show last N lines ────────────────────────────────────────────
+        try:
+            all_lines = log_file.read_text().splitlines()
+            if not all_lines:
+                Console.info("Log file is empty")
+                return
+
+            show_lines = all_lines[-min(lines, len(all_lines)):]
+
+            Console.info(f"{log_file} ({len(all_lines)} total lines)")
+            Console.newline()
+
+            for line in show_lines:
+                Console.print(f"  {Colors.DIM}{line}{Colors.RESET}")
+
+            Console.newline()
+            Console.info(f"Run 'ghost logs -f' to follow in real-time")
+
+        except OSError as e:
+            Console.error(f"Error reading log: {e}")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/ghost/daemon.py
+++ b/ghost/daemon.py
@@ -1,0 +1,365 @@
+"""
+Ghost Daemon - Project-scoped background process for file watching.
+
+Manages a persistent file watcher per project that survives terminal disconnection.
+Communicates with the CLI via PID file (.ghost/pid) and logs (.ghost/logs/ghost.log).
+
+Usage (called by CLI, not directly):
+    python -m ghost.daemon /path/to/project
+"""
+
+import os
+import sys
+import time
+import signal
+import logging
+import threading
+from pathlib import Path
+from logging.handlers import RotatingFileHandler
+from typing import Optional
+
+# Ensure ghost package is importable when launched as subprocess
+_GHOST_DIR = Path(__file__).parent.resolve()
+if str(_GHOST_DIR) not in sys.path:
+    sys.path.insert(0, str(_GHOST_DIR))
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Global shutdown coordination
+# ──────────────────────────────────────────────────────────────────────────────
+
+_shutdown = threading.Event()
+
+
+def _signal_handler(signum: int, frame) -> None:
+    """Signal handler: set shutdown event to trigger graceful stop.
+
+    Must be async-signal-safe — only sets a flag, never allocates or logs.
+    """
+    _shutdown.set()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Logging
+# ──────────────────────────────────────────────────────────────────────────────
+
+def setup_daemon_logging(log_dir: Path) -> logging.Logger:
+    """Configure rotating file logging for the daemon process.
+
+    Args:
+        log_dir: Directory to store log files (e.g. .ghost/logs).
+
+    Returns:
+        Configured logger instance.
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "ghost.log"
+
+    logger = logging.getLogger("ghost.daemon")
+    logger.setLevel(logging.DEBUG)
+
+    # Rotating file handler: 10 MB per file, keep 5 backups
+    handler = RotatingFileHandler(
+        str(log_file),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=5,
+        delay=True,  # Don't open until first write
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    # Also mirror WARNING+ to stderr so errors surface in terminal
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(formatter)
+    logger.addHandler(stderr_handler)
+
+    return logger
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# PID file management
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _write_pid(pid_file: Path) -> None:
+    """Write the current process PID to the PID file atomically."""
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    # Write and fsync atomically — keep fd open during sync
+    fd = os.open(str(pid_file), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o644)
+    try:
+        os.write(fd, f"{os.getpid()}\n".encode())
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _remove_pid(pid_file: Path) -> None:
+    """Remove the PID file only if it belongs to this process."""
+    try:
+        if pid_file.exists() and pid_file.read_text().strip() == str(os.getpid()):
+            pid_file.unlink()
+    except (OSError, ValueError):
+        pass
+
+
+def check_pid(pid_file: Path) -> Optional[int]:
+    """Check if a daemon is running via PID file + os.kill(pid, 0).
+
+    Args:
+        pid_file: Path to the PID file.
+
+    Returns:
+        The PID if running, or None if not running / stale.
+    """
+    if not pid_file.exists():
+        return None
+    try:
+        pid = int(pid_file.read_text().strip())
+        os.kill(pid, 0)  # No-op if alive, raises OSError if dead
+        return pid
+    except (OSError, ValueError):
+        # Stale PID file — clean it up
+        try:
+            pid_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Daemon runner (core logic)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _load_env(project_root: Path) -> None:
+    """Load .env from the project root if it exists."""
+    env_file = project_root / ".env"
+    if env_file.exists():
+        try:
+            from dotenv import load_dotenv
+
+            load_dotenv(env_file, override=True)
+        except ImportError:
+            pass  # dotenv is optional for daemon
+
+
+def _build_watcher(project_root: Path, logger: logging.Logger):
+    """Build and start the watchdog file observer.
+
+    This replicates the watcher logic from main.start_watching() but
+    adapted for daemon use (no console output, all goes to log).
+
+    Args:
+        project_root: Root directory to watch.
+        logger: Logger instance for daemon.
+
+    Returns:
+        The started Observer instance.
+    """
+    from watchdog.observers import Observer
+    from watchdog.events import FileSystemEventHandler, FileSystemEvent
+
+    # Debounce state per daemon instance
+    last_processed: dict = {}
+    currently_processing: set = set()
+    DEBOUNCE_SECONDS = 15
+
+    class DaemonEventHandler(FileSystemEventHandler):
+        """Watchdog event handler that logs all activity and triggers test gen."""
+
+        def _should_process(self, file_path: str) -> bool:
+            if file_path in currently_processing:
+                return False
+            current_time = time.time()
+            if file_path in last_processed:
+                if current_time - last_processed[file_path] < DEBOUNCE_SECONDS:
+                    return False
+            return True
+
+        def _mark_start(self, file_path: str) -> None:
+            currently_processing.add(file_path)
+
+        def _mark_done(self, file_path: str) -> None:
+            currently_processing.discard(file_path)
+            last_processed[file_path] = time.time()
+
+        def _get_file(self, event: FileSystemEvent) -> Optional[str]:
+            path = str(event.src_path)
+            if path.endswith("~"):
+                path = path[:-1]
+            return path
+
+        def _check_path(self, file_path: str) -> bool:
+            """Check if path should be watched (replicates main.CheckPath logic)."""
+            normalized = file_path.replace("\\", "/")
+            if "/tests/" in normalized or normalized.endswith("/tests"):
+                return False
+            if "/__pycache__/" in normalized or normalized.endswith(".pyc"):
+                return False
+            file = normalized.split("/")[-1] if "/" in normalized else file_path
+            if "test" in file.lower() or "tmp" in file.lower():
+                return False
+            if file.startswith(".git") or file.endswith(".log"):
+                return False
+            if not file.endswith(".py"):
+                return False
+            return True
+
+        def on_modified(self, event: FileSystemEvent) -> None:
+            file_path = self._get_file(event)
+            if not file_path or not self._check_path(file_path):
+                return
+            if not self._should_process(file_path):
+                return
+
+            self._mark_start(file_path)
+            try:
+                file_name = file_path.split("/")[-1]
+                logger.info(f"File modified: {file_name}")
+
+                # Read source content
+                try:
+                    with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+                        content = f.read()
+                except (FileNotFoundError, PermissionError, OSError) as e:
+                    logger.warning(f"Cannot read file {file_path}: {e}")
+                    return
+
+                # Update project context JSON
+                try:
+                    import init as ghost_init_module
+
+                    result = ghost_init_module.walk_and_modify_json(
+                        str(project_root), file_path, file_name
+                    )
+                    if result is None:
+                        logger.warning(f"Skipping {file_name}: syntax errors")
+                        return
+                except Exception as e:
+                    logger.error(f"Failed to update context for {file_name}: {e}")
+                    return
+
+                # Generate tests
+                try:
+                    from chat import TestGenerator
+                    from config import get_config
+
+                    config = get_config(project_root)
+                    generator = TestGenerator(config=config)
+                    code = generator.get_test_code(content, str(project_root), file_name)
+
+                    # Write test file
+                    tests_dir = project_root / "tests"
+                    tests_dir.mkdir(exist_ok=True)
+                    test_path = tests_dir / f"test_{file_name}"
+                    test_path.write_text(code)
+                    logger.info(f"Tests generated: test_{file_name}")
+                except Exception as e:
+                    logger.error(f"Test generation failed for {file_name}: {e}")
+
+            finally:
+                self._mark_done(file_path)
+
+        def on_created(self, event: FileSystemEvent) -> None:
+            file_path = self._get_file(event)
+            if file_path and self._check_path(file_path):
+                logger.info(f"File created: {file_path.split('/')[-1]}")
+
+        def on_deleted(self, event: FileSystemEvent) -> None:
+            file_path = self._get_file(event)
+            if file_path and self._check_path(file_path):
+                file_name = file_path.split("/")[-1]
+                logger.info(f"File deleted: {file_name}")
+                try:
+                    import init as ghost_init_module
+
+                    ghost_init_module.walk_and_delete_json(str(project_root), file_name)
+                except Exception as e:
+                    logger.error(f"Failed to remove {file_name} from context: {e}")
+
+    event_handler = DaemonEventHandler()
+    observer = Observer()
+    observer.schedule(event_handler, path=str(project_root), recursive=True)
+    observer.start()
+    return observer
+
+
+def run_daemon(project_root_str: str) -> None:
+    """Main entry point for the daemon process.
+
+    Called from subprocess via `python -m ghost.daemon <project_root>`.
+
+    Args:
+        project_root_str: Absolute path to the project root directory.
+    """
+    project_root = Path(project_root_str).resolve()
+    ghost_dir = project_root / ".ghost"
+    log_dir = ghost_dir / "logs"
+    pid_file = ghost_dir / "pid"
+
+    # ── Signal handling ──────────────────────────────────────────────────
+    try:
+        signal.signal(signal.SIGTERM, _signal_handler)
+        signal.signal(signal.SIGINT, _signal_handler)
+        signal.signal(signal.SIGHUP, signal.SIG_IGN)  # Terminal HUP → ignore
+    except ValueError:
+        # Not in main thread; signals can't be set. This is fine when
+        # running in a subprocess (the child's main thread handles signals).
+        pass
+
+    # ── Write PID file ───────────────────────────────────────────────────
+    _write_pid(pid_file)
+
+    # ── Logging ──────────────────────────────────────────────────────────
+    logger = setup_daemon_logging(log_dir)
+    logger.info(f"Ghost daemon starting (PID: {os.getpid()})")
+    logger.info(f"Project root: {project_root}")
+    logger.info(f"Log file: {log_dir / 'ghost.log'}")
+
+    # ── Load environment ─────────────────────────────────────────────────
+    _load_env(project_root)
+
+    # Redirect stdout/stderr to prevent accidental usage in daemon mode
+    sys.stdout = open(os.devnull, "w")  # noqa: SIM115
+    sys.stderr = open(os.devnull, "w")  # noqa: SIM115
+
+    observer = None
+    last_error: Optional[str] = None
+
+    try:
+        # ── Start watcher ────────────────────────────────────────────────
+        observer = _build_watcher(project_root, logger)
+        logger.info("File watcher started successfully")
+
+        # ── Block until shutdown signal ──────────────────────────────────
+        _shutdown.wait()
+
+    except Exception as e:
+        last_error = f"{type(e).__name__}: {e}"
+        logger.exception(f"Daemon error: {last_error}")
+    finally:
+        logger.info("Daemon shutting down...")
+
+        if observer is not None:
+            try:
+                observer.stop()
+                observer.join(timeout=10)
+            except Exception as e:
+                logger.warning(f"Observer shutdown warning: {e}")
+
+        _remove_pid(pid_file)
+        logger.info("Daemon stopped")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Entry point (python -m ghost.daemon <project_root>)
+# ──────────────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python -m ghost.daemon <project_root>", file=sys.stderr)
+        sys.exit(1)
+
+    run_daemon(sys.argv[1])


### PR DESCRIPTION
## Summary

Implements background daemon mode for the Ghost test watcher, tied to each project via `.ghost/pid` and `.ghost/logs/ghost.log`.

## Commands Added

- **`ghost start [PATH]`** — Starts the file watcher. Uses `--detach` (default) to run as a background daemon, or `--foreground` to run interactively.
- **`ghost stop [PATH]`** — Sends SIGTERM for graceful shutdown, then SIGKILL after 10s timeout.
- **`ghost status [PATH]`** — Reports running/not running, PID, and last 10 log entries.
- **`ghost logs [PATH]`** — Shows recent log lines; `--follow`/`-f` tails in real-time (like `tail -f`).

## Architecture

| Component | Approach |
|-----------|----------|
| **Process detachment** | `subprocess.Popen` with `start_new_session=True` (calls `setsid()`) — no double-fork needed |
| **Health checks** | `os.kill(pid, 0)` with automatic stale PID cleanup |
| **PID file** | Atomic write with `os.open(O_CREAT \| O_WRONLY \| O_TRUNC)` + `os.fsync` |
| **Logging** | `RotatingFileHandler` (10 MB per file, 5 backups) |
| **Shutdown** | `threading.Event`-based signal handler for SIGTERM/SIGINT |
| **Scope** | Per-project: PID and logs stored in `.ghost/` |

## Testing

Tested end-to-end: init → start (detached) → status → logs → stop → status-after-stop. All commands work correctly. Daemon writes PID, watches files, and cleans up on shutdown.

Closes #1