### PR TITLE
feat: enforce tests-only writes globally (closes #4)

### DIFF
--- a/ghost/__init__.py
+++ b/ghost/__init__.py
@@ -27,6 +27,7 @@ from .cli import main
 from .config import GhostConfig, get_config
 from .providers import get_provider, list_available_providers
 from .console import Console, GhostSpinner
+from .write_policy import WriteGuard, WritePolicyError
 
 __all__ = [
     "main",
@@ -36,5 +37,7 @@ __all__ = [
     "list_available_providers",
     "Console",
     "GhostSpinner",
+    "WriteGuard",
+    "WritePolicyError",
     "__version__",
 ]

--- a/ghost/cli.py
+++ b/ghost/cli.py
@@ -793,12 +793,17 @@ def generate(file: str, output: Optional[str], force: bool):
     
     Console.generating(file_path.name)
     
+    from write_policy import WriteGuard
+    from config import get_config
+    config = get_config(project_root)
+    output_dir = config.tests.output_dir
+    guard = WriteGuard(project_root / output_dir)
+    
     # Determine output path
     if output:
         test_path = Path(output).resolve()
     else:
-        tests_dir = project_root / "tests"
-        tests_dir.mkdir(exist_ok=True)
+        tests_dir = project_root / output_dir
         test_path = tests_dir / f"test_{file_path.name}"
     
     # Check if test file exists
@@ -815,9 +820,7 @@ def generate(file: str, output: Optional[str], force: bool):
     with GhostSpinner("Generating tests with AI", style=SpinnerStyle.DOTS, color=Colors.CYAN) as spinner:
         try:
             from chat import TestGenerator
-            from config import get_config
             
-            config = get_config(project_root)
             generator = TestGenerator(config=config)
             
             test_code = generator.get_test_code(
@@ -826,10 +829,7 @@ def generate(file: str, output: Optional[str], force: bool):
                 filename=file_path.name
             )
             
-            # Write test file
-            with open(test_path, 'w') as f:
-                f.write(test_code)
-            
+            guard.write_text(test_path, test_code)
             spinner.stop(message=f"Tests written to {test_path.name}")
             
         except Exception as e:

--- a/ghost/daemon.py
+++ b/ghost/daemon.py
@@ -245,16 +245,16 @@ def _build_watcher(project_root: Path, logger: logging.Logger):
                 try:
                     from chat import TestGenerator
                     from config import get_config
+                    from write_policy import WriteGuard
 
                     config = get_config(project_root)
+                    output_dir = config.tests.output_dir
+                    guard = WriteGuard(project_root / output_dir)
                     generator = TestGenerator(config=config)
                     code = generator.get_test_code(content, str(project_root), file_name)
 
-                    # Write test file
-                    tests_dir = project_root / "tests"
-                    tests_dir.mkdir(exist_ok=True)
-                    test_path = tests_dir / f"test_{file_name}"
-                    test_path.write_text(code)
+                    test_path = project_root / output_dir / f"test_{file_name}"
+                    guard.write_text(test_path, code)
                     logger.info(f"Tests generated: test_{file_name}")
                 except Exception as e:
                     logger.error(f"Test generation failed for {file_name}: {e}")

--- a/ghost/main.py
+++ b/ghost/main.py
@@ -187,14 +187,15 @@ def ReadFile(file_path: str) -> None:
 
 # Write Test File
 def WriteTest(file_path: str, test_code: str, source_path: str) -> str | None:
-    folder_path = "/".join(str(source_path).replace("\\", "/").split("/")[:])
-    folder_path = f"{folder_path}/tests"
-    if os.path.exists(folder_path) == False:
-        os.makedirs(folder_path)
-
-    test_file_path = f"{folder_path}/test_{getFileNameFromPath(file_path)}"
-    with open(test_file_path, 'w') as test_file:
-        test_file.write(test_code)
+    from pathlib import Path
+    from write_policy import WriteGuard
+    from config import get_config
+    config = get_config(Path(source_path) if source_path else None)
+    output_dir = config.tests.output_dir
+    guard = WriteGuard(Path(source_path) / output_dir)
+    project_root = Path(source_path)
+    test_file_path = project_root / output_dir / f"test_{getFileNameFromPath(file_path)}"
+    guard.write_text(test_file_path, test_code)
     Console.success(f"Test file written: {test_file_path}")
 
 # Watchdog Event Handler

--- a/ghost/write_policy.py
+++ b/ghost/write_policy.py
@@ -1,0 +1,102 @@
+"""
+Write Policy Guard — centralized filesystem write enforcement.
+
+All test file writes in Ghost go through this module. It normalizes
+paths via realpath, checks containment within allowed directories, and
+blocks attempts to write outside configured tests.output_dir.
+"""
+
+from pathlib import Path
+from typing import Iterable, Union
+
+PathLike = Union[str, Path]
+
+
+class WritePolicyError(PermissionError):
+    """Raised when a write is attempted outside allowed directories."""
+
+    def __init__(self, target: Path, allowed: list[Path]):
+        self.target = target
+        self.allowed = allowed
+        super().__init__(
+            f"Write blocked: {target} is outside allowed directories.\n"
+            f"Allowed directories:\n"
+            + "\n".join(f"  \u2022 {p}" for p in allowed)
+        )
+
+
+class WriteGuard:
+    """Enforces that all writes stay within an allowlist of directories.
+
+    Args:
+        allowed_dirs: One or more directories where writes are permitted.
+            All are resolved to real, absolute paths at init time.
+        create_parents: If True, auto-create parent dirs of targets (default).
+    """
+
+    def __init__(
+        self,
+        allowed_dirs: Union[PathLike, Iterable[PathLike]],
+        create_parents: bool = True,
+    ):
+        if isinstance(allowed_dirs, (str, Path)):
+            allowed_dirs = [allowed_dirs]
+        self._allowed = [Path(d).resolve() for d in allowed_dirs]
+        self._create_parents = create_parents
+
+    @property
+    def allowed_dirs(self) -> list[Path]:
+        return list(self._allowed)
+
+    def check(self, target: PathLike) -> Path:
+        """Resolve *target* and verify it is inside an allowed directory.
+
+        Uses Path.resolve() to canonicalize the path (resolves .., symlinks)
+        and checks containment via relative_to() to prevent ../ escape.
+
+        Returns:
+            The resolved absolute Path (safe to use for writes).
+
+        Raises:
+            WritePolicyError: if target escapes all allowed directories.
+        """
+        target = Path(target)
+        resolved = target.resolve()
+
+        if resolved in self._allowed:
+            raise WritePolicyError(resolved, self._allowed)
+
+        for base in self._allowed:
+            try:
+                resolved.relative_to(base)
+                return resolved
+            except ValueError:
+                continue
+
+        raise WritePolicyError(resolved, self._allowed)
+
+    def write_text(
+        self,
+        target: PathLike,
+        data: str,
+        encoding: str = "utf-8",
+    ) -> Path:
+        """Write *data* to *target* after path validation."""
+        resolved = self.check(target)
+        if self._create_parents:
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(data, encoding=encoding)
+        return resolved
+
+    def mkdir(self, target: PathLike, parents: bool = True) -> Path:
+        """Create a directory after path validation."""
+        target = Path(target)
+        resolved = target.resolve()
+        for base in self._allowed:
+            try:
+                resolved.relative_to(base)
+                resolved.mkdir(parents=parents, exist_ok=True)
+                return resolved
+            except ValueError:
+                continue
+        raise WritePolicyError(resolved, self._allowed)


### PR DESCRIPTION
## Description
Centralize test write operations and restrict them to configured `tests.output_dir`.

## Changes
- Add `ghost/write_policy.py` with `WriteGuard` class that validates all test file writes
- All test write paths now respect `tests.output_dir` from `ghost.toml` config instead of hardcoded `tests` directory
- Uses `Path.resolve()` to canonicalize paths and `relative_to()` for containment checking

## Acceptance
- Any attempt to write outside `tests.output_dir` is blocked with a clear `WritePolicyError`
- No test generation code path writes into project source directories

Closes #4