### PR TITLE
feat: replace ad-hoc debounce with real job queue (closes #9)

### DIFF
--- a/ghost/__init__.py
+++ b/ghost/__init__.py
@@ -27,6 +27,7 @@ from .cli import main
 from .config import GhostConfig, get_config
 from .providers import get_provider, list_available_providers
 from .console import Console, GhostSpinner
+from .job_queue import JobQueue
 
 __all__ = [
     "main",
@@ -36,5 +37,6 @@ __all__ = [
     "list_available_providers",
     "Console",
     "GhostSpinner",
+    "JobQueue",
     "__version__",
 ]

--- a/ghost/daemon.py
+++ b/ghost/daemon.py
@@ -160,30 +160,18 @@ def _build_watcher(project_root: Path, logger: logging.Logger):
     """
     from watchdog.observers import Observer
     from watchdog.events import FileSystemEventHandler, FileSystemEvent
+    from job_queue import JobQueue
+    from config import get_config
 
-    # Debounce state per daemon instance
-    last_processed: dict = {}
-    currently_processing: set = set()
-    DEBOUNCE_SECONDS = 15
+    config = get_config(project_root)
+    queue = JobQueue(
+        debounce_seconds=config.watcher.debounce_seconds,
+        max_workers=1,
+    )
+    queue.start()
 
     class DaemonEventHandler(FileSystemEventHandler):
         """Watchdog event handler that logs all activity and triggers test gen."""
-
-        def _should_process(self, file_path: str) -> bool:
-            if file_path in currently_processing:
-                return False
-            current_time = time.time()
-            if file_path in last_processed:
-                if current_time - last_processed[file_path] < DEBOUNCE_SECONDS:
-                    return False
-            return True
-
-        def _mark_start(self, file_path: str) -> None:
-            currently_processing.add(file_path)
-
-        def _mark_done(self, file_path: str) -> None:
-            currently_processing.discard(file_path)
-            last_processed[file_path] = time.time()
 
         def _get_file(self, event: FileSystemEvent) -> Optional[str]:
             path = str(event.src_path)
@@ -192,7 +180,6 @@ def _build_watcher(project_root: Path, logger: logging.Logger):
             return path
 
         def _check_path(self, file_path: str) -> bool:
-            """Check if path should be watched (replicates main.CheckPath logic)."""
             normalized = file_path.replace("\\", "/")
             if "/tests/" in normalized or normalized.endswith("/tests"):
                 return False
@@ -207,60 +194,46 @@ def _build_watcher(project_root: Path, logger: logging.Logger):
                 return False
             return True
 
+        def _process_file(self, file_path: str) -> None:
+            file_name = file_path.split("/")[-1]
+            logger.info(f"File modified: {file_name}")
+
+            try:
+                with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+                    content = f.read()
+            except (FileNotFoundError, PermissionError, OSError) as e:
+                logger.warning(f"Cannot read file {file_path}: {e}")
+                return
+
+            try:
+                import init as ghost_init_module
+                result = ghost_init_module.walk_and_modify_json(
+                    str(project_root), file_path, file_name
+                )
+                if result is None:
+                    logger.warning(f"Skipping {file_name}: syntax errors")
+                    return
+            except Exception as e:
+                logger.error(f"Failed to update context for {file_name}: {e}")
+                return
+
+            try:
+                from chat import TestGenerator
+
+                generator = TestGenerator(config=config)
+                code = generator.get_test_code(content, str(project_root), file_name)
+
+                test_path = project_root / config.tests.output_dir / f"test_{file_name}"
+                test_path.write_text(code)
+                logger.info(f"Tests generated: test_{file_name}")
+            except Exception as e:
+                logger.error(f"Test generation failed for {file_name}: {e}")
+
         def on_modified(self, event: FileSystemEvent) -> None:
             file_path = self._get_file(event)
             if not file_path or not self._check_path(file_path):
                 return
-            if not self._should_process(file_path):
-                return
-
-            self._mark_start(file_path)
-            try:
-                file_name = file_path.split("/")[-1]
-                logger.info(f"File modified: {file_name}")
-
-                # Read source content
-                try:
-                    with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
-                        content = f.read()
-                except (FileNotFoundError, PermissionError, OSError) as e:
-                    logger.warning(f"Cannot read file {file_path}: {e}")
-                    return
-
-                # Update project context JSON
-                try:
-                    import init as ghost_init_module
-
-                    result = ghost_init_module.walk_and_modify_json(
-                        str(project_root), file_path, file_name
-                    )
-                    if result is None:
-                        logger.warning(f"Skipping {file_name}: syntax errors")
-                        return
-                except Exception as e:
-                    logger.error(f"Failed to update context for {file_name}: {e}")
-                    return
-
-                # Generate tests
-                try:
-                    from chat import TestGenerator
-                    from config import get_config
-
-                    config = get_config(project_root)
-                    generator = TestGenerator(config=config)
-                    code = generator.get_test_code(content, str(project_root), file_name)
-
-                    # Write test file
-                    tests_dir = project_root / "tests"
-                    tests_dir.mkdir(exist_ok=True)
-                    test_path = tests_dir / f"test_{file_name}"
-                    test_path.write_text(code)
-                    logger.info(f"Tests generated: test_{file_name}")
-                except Exception as e:
-                    logger.error(f"Test generation failed for {file_name}: {e}")
-
-            finally:
-                self._mark_done(file_path)
+            queue.submit(file_path, self._process_file)
 
         def on_created(self, event: FileSystemEvent) -> None:
             file_path = self._get_file(event)

--- a/ghost/job_queue.py
+++ b/ghost/job_queue.py
@@ -1,0 +1,166 @@
+"""
+Job Queue — lightweight debounce + sequential processing for file events.
+
+Architecture:
+    Watchdog Handler -> TimerDebouncer -> JobQueue -> Worker
+
+The watchdog handler calls queue.submit(file_path, callback).
+The debouncer collapses rapid re-submits of the same path into one job.
+The worker processes jobs in FIFO order on a dedicated thread.
+"""
+
+import threading
+import time
+from typing import Callable, Optional, Any
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from collections import OrderedDict
+from queue import Queue, Empty
+
+
+class JobState(Enum):
+    PENDING = auto()
+    RUNNING = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+
+
+@dataclass
+class Job:
+    path: str
+    callback: Callable[[str], Any]
+    created_at: float = field(default_factory=time.time)
+    state: JobState = JobState.PENDING
+    error: Optional[str] = None
+
+
+class TimerDebouncer:
+    """Debounce layer: one timer per file path.
+
+    Each new submit() for a path resets its timer. Only after *delay* seconds
+    with no new events does the job proceed to the queue.
+    """
+
+    def __init__(self, on_ready: Callable[[str], None], delay: float = 2.0):
+        self._on_ready = on_ready
+        self._delay = delay
+        self._timers: dict[str, threading.Timer] = {}
+        self._lock = threading.Lock()
+
+    def submit(self, path: str) -> None:
+        with self._lock:
+            existing = self._timers.get(path)
+            if existing is not None:
+                existing.cancel()
+            timer = threading.Timer(self._delay, self._fire, args=[path])
+            timer.daemon = True
+            timer.start()
+            self._timers[path] = timer
+
+    def _fire(self, path: str) -> None:
+        with self._lock:
+            self._timers.pop(path, None)
+        self._on_ready(path)
+
+    def cancel(self, path: Optional[str] = None) -> None:
+        with self._lock:
+            if path:
+                timer = self._timers.pop(path, None)
+                if timer:
+                    timer.cancel()
+            else:
+                for timer in self._timers.values():
+                    timer.cancel()
+                self._timers.clear()
+
+    @property
+    def pending_paths(self) -> list[str]:
+        with self._lock:
+            return list(self._timers.keys())
+
+
+class JobQueue:
+    """Ordered, single-worker job queue with per-file dedup.
+
+    The watchdog handler should call ``queue.submit(path, callback)``.
+    The worker picks up jobs in FIFO order and runs them on a single thread.
+    """
+
+    def __init__(
+        self,
+        debounce_seconds: float = 2.0,
+        max_workers: int = 1,
+    ):
+        self._debounce_seconds = debounce_seconds
+        self._max_workers = max_workers
+        self._queue: Queue[Job] = Queue()
+        self._workers: list[threading.Thread] = []
+        self._running = False
+        self._active: OrderedDict[str, Job] = OrderedDict()
+        self._lock = threading.Lock()
+        self._debouncer = TimerDebouncer(
+            on_ready=self._enqueue,
+            delay=debounce_seconds,
+        )
+
+    def submit(self, path: str, callback: Callable[[str], Any]) -> None:
+        with self._lock:
+            if path in self._active:
+                self._active[path].callback = callback
+                self._active.move_to_end(path)
+            else:
+                job = Job(path=path, callback=callback)
+                self._active[path] = job
+
+        self._debouncer.submit(path)
+
+    def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        for i in range(self._max_workers):
+            t = threading.Thread(
+                target=self._worker_loop,
+                name=f"ghost-worker-{i}",
+                daemon=True,
+            )
+            t.start()
+            self._workers.append(t)
+
+    def stop(self, timeout: float = 10.0) -> None:
+        self._running = False
+        self._debouncer.cancel()
+        for t in self._workers:
+            t.join(timeout=timeout)
+        self._workers.clear()
+
+    @property
+    def pending_count(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def debouncing_count(self) -> int:
+        return len(self._debouncer.pending_paths)
+
+    def _enqueue(self, path: str) -> None:
+        with self._lock:
+            job = self._active.pop(path, None)
+        if job is not None:
+            self._queue.put(job)
+
+    def _worker_loop(self) -> None:
+        while self._running:
+            try:
+                job = self._queue.get(timeout=0.5)
+            except Empty:
+                continue
+
+            job.state = JobState.RUNNING
+            try:
+                job.callback(job.path)
+                job.state = JobState.COMPLETED
+            except Exception as exc:
+                job.state = JobState.FAILED
+                job.error = f"{type(exc).__name__}: {exc}"
+            finally:
+                self._queue.task_done()

--- a/ghost/main.py
+++ b/ghost/main.py
@@ -199,41 +199,32 @@ def WriteTest(file_path: str, test_code: str, source_path: str) -> str | None:
 
 # Watchdog Event Handler
 def start_watching(path_to_watch):
-    # Load .env from the project directory
     from pathlib import Path
     from dotenv import load_dotenv
+    from job_queue import JobQueue
+    from config import get_config
     project_path = Path(path_to_watch).resolve()
     env_file = project_path / ".env"
     if env_file.exists():
         load_dotenv(env_file, override=True)
-    
-    # Debounce mechanism to prevent duplicate events
-    last_processed = {}
-    currently_processing = set()  # Track files being processed
-    DEBOUNCE_SECONDS = 15  # Ignore events for the same file within this window (increased for rate limiting)
-    
+
+    config = get_config(project_path)
+    queue = JobQueue(
+        debounce_seconds=config.watcher.debounce_seconds,
+        max_workers=1,
+    )
+    queue.start()
+
     class MyEventHandler(FileSystemEventHandler):
-        def _should_process(self, file_path):
-            """Check if we should process this file (debouncing)."""
-            # Skip if file is currently being processed
-            if file_path in currently_processing:
-                return False
-            current_time = time.time()
-            if file_path in last_processed:
-                if current_time - last_processed[file_path] < DEBOUNCE_SECONDS:
-                    return False
-            return True
-        
-        def _mark_processing_start(self, file_path):
-            """Mark file as being processed."""
-            currently_processing.add(file_path)
-        
-        def _mark_processing_done(self, file_path):
-            """Mark file processing as complete and update timestamp."""
-            currently_processing.discard(file_path)
-            last_processed[file_path] = time.time()
-        
-        def on_created(self, event: FileSystemEvent) -> None: #When a file is created
+        def _process_file(self, file_path: str) -> None:
+            file = getFileNameFromPath(file_path)
+            Console.file_changed(file, "modified")
+            content = ReadFile(file_path)
+            result = ghost_init_module.walk_and_modify_json(path_to_watch, file_path, file)
+            if result is not None:
+                make_tests(file_path, content, str(path_to_watch), file)
+
+        def on_created(self, event: FileSystemEvent) -> None:
             pathhh = str(event.src_path)
             if pathhh.endswith("~"):
                 event.src_path = pathhh[:-1]
@@ -243,7 +234,7 @@ def start_watching(path_to_watch):
             if CheckPath(file, str(event.src_path)):
                 Console.file_changed(file, "created")
 
-        def on_deleted(self, event: FileSystemEvent) -> None: #When a file is deleted
+        def on_deleted(self, event: FileSystemEvent) -> None:
             pathhh = str(event.src_path)
             if pathhh.endswith("~"):
                 event.src_path = pathhh[:-1]
@@ -254,27 +245,14 @@ def start_watching(path_to_watch):
                 Console.file_changed(file, "deleted")
                 ghost_init_module.walk_and_delete_json(path_to_watch, file)
 
-        def on_modified(self, event: FileSystemEvent) -> None: #When a file is modified
+        def on_modified(self, event: FileSystemEvent) -> None:
             pathhh = str(event.src_path)
             if "__pycache__" in pathhh or pathhh.endswith(".pyc"):
                 return
             if not pathhh.endswith("~"):
-
                 file = getFileNameFromPath(str(event.src_path))
-                # file_bad = getFileNameFromPath(pathhh)
-                if CheckPath(file, str(event.src_path)) and self._should_process(str(event.src_path)):
-                    self._mark_processing_start(str(event.src_path))
-                    try:
-                        Console.file_changed(file, "modified")
-                        content = ReadFile(str(event.src_path))
-                        # logging.info("File content:\n%s", content)
-                        result = ghost_init_module.walk_and_modify_json(path_to_watch, str(event.src_path), file)
-                        # Skip test generation if file has syntax errors
-                        if result is not None:
-                            # Pass: file_path (the modified file), content, source_path (project root), filename
-                            make_tests(str(event.src_path), content, str(path_to_watch), file)
-                    finally:
-                        self._mark_processing_done(str(event.src_path))
+                if CheckPath(file, str(event.src_path)):
+                    queue.submit(str(event.src_path), self._process_file)
 
     event_handler = MyEventHandler()
     observer = Observer()
@@ -287,6 +265,7 @@ def start_watching(path_to_watch):
         while True:
             time.sleep(1)
     finally:
+        queue.stop()
         observer.stop()
         observer.join()
 


### PR DESCRIPTION
## Description
Replace the duplicated, racy ad-hoc debounce logic with a proper job queue that guarantees in-order processing.

## Changes
- New `job_queue.py` with `JobQueue` and `TimerDebouncer` classes
- Watchdog handlers are now stateless — they only enqueue events
- Removes duplicated debounce logic from `main.py` and `daemon.py`
- Reads `debounce_seconds` from config instead of hardcoded 15s
- Multiple file saves within debounce window collapse to 1 job

## Acceptance
- Watchdog handler only enqueues file events
- Worker processes in order (single worker by default)
- Multiple file saves collapse to 1 job per file in debounce window

Closes #9